### PR TITLE
Fixes #177: Adding Logstash Support

### DIFF
--- a/glastopf/glastopf.cfg.dist
+++ b/glastopf/glastopf.cfg.dist
@@ -77,6 +77,12 @@ include_contact_info = False
 contact_name = ...
 contact_email = ...
 
+[logstash]
+enabled = True
+host = localhost
+port = 5659
+handler = AMQP/TCP/UDP 
+
 [misc]
 # set webserver banner
 banner = Apache/2.0.48

--- a/glastopf/modules/reporting/auxiliary/log_logstash.py
+++ b/glastopf/modules/reporting/auxiliary/log_logstash.py
@@ -1,0 +1,64 @@
+import logging
+import logstash
+
+logger = logging.getLogger(__name__)
+
+
+# Global logger for logstash provides an interface for different brokers
+
+from glastopf.modules.reporting.auxiliary.base_logger import BaseLogger
+
+class LogLogStash(BaseLogger):
+	def __init__(self, data_dir, config="glastopf.cfg"):
+		BaseLogger.__init__(self, config)
+
+		if self.config.getboolean("logstash", "enabled"):
+			self.host = self.config.get("logstash", "host")
+			self.port = int(self.config.getint("logstash", "port"))
+			self.options = {
+			 	"enabled": self.config.getboolean("logstash", "enabled"),
+			}
+		
+			self.handler = self.config.get("logstash", "handler")
+
+			if self.handler == "AMQP":
+				self.username = self.config.get("logstash", "username")
+				self.password = self.config.get("logstash", "password")
+				self.exchange = self.config.get("logstash", "exchange")
+				self.durable = self.config.getboolean("logstash", "durable")
+			elif self.handler != "TCP" and self.handler != "UDP":
+				raise Exception("Incorrect logstash handler defined, please use AMQP, UDP or TCP")
+
+			self._setupHandler()
+
+	def _setupHandler(self):
+		logstashHandler = None
+
+		if self.handler == 'AMQP':
+			logstashHandler = logstash.AMQPLogstashHandler(version=1,
+                                                    host=self.host,
+                                                    durable=self.durable,
+                                                    username=self.username,
+                                                    password=self.password,
+                                                    exchange=self.exchange )
+		elif self.handler == 'TCP':
+			logstashHandler = logstash.LogstashHandler(self.host, self.port, version=1)
+		elif self.handler == "UDP":
+			logstashHandler = logstash.LogstashHandler(self.host, self.port, version=1)
+
+		self.attack_logger = logging.getLogger('python-logstash-handler')
+		self.attack_logger.setLevel(logging.INFO)
+		self.attack_logger.addHandler(logstashHandler)
+
+	def insert(self, attack_event):
+		message = "Glaspot: %(pattern)s attack method from %(source)s against %(host)s:%(port)s. [%(method)s %(url)s]" % {
+			'pattern': attack_event.matched_pattern,
+			'source': ':'.join((attack_event.source_addr[0], str(attack_event.source_addr[1]))),
+			'host': attack_event.sensor_addr[0],
+			'port': attack_event.sensor_addr[1],
+			'method': attack_event.http_request.request_verb,
+			'url': attack_event.http_request.request_url,
+        		}
+		self.attack_logger.info(message)
+
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ MySQL-python
 hpfeeds
 pylibinjection
 libtaxii
+python-logstash


### PR DESCRIPTION
This PR supports pushing attack log data to logstash.

Although, I'm still open to what data I should be pushing to the logstash server. I have modelled the data around the log handler provided via log_syslog handler. 

I guess I can say my motivation for using logstash. I basically want to create a visual dashboard, that can collect results from multiple a cluster of glastopf server, and use something like Kibana or Graphite (or even d3) to visualize and display the results. So the information currently being pushed to logstash isn't the greatest (i.e all the information is there just not in a good format).

I tried using the already defined method event_dict() on the attack event object, but python isn't my "forte" and wasn't able to make it work. I *think* the problem is associated with how record objects, are created and it can't share the same fields, within the extra parameter, but I couldn't see any fields that were shared :/.

*EDIT:* Ok I learnt about grok in logstash. so you can manually parse the log data :P which gives me what I require. So do we just let it be done via logstash or we can change the log data thats parsed back :)

Please excuse my noobness :P

Things to note:
- I haven't manually tested the use of the AMQP handler.

Still to do:
- [ ] Add tests to support logstash
- [ ] Need to add documentation on setting up logstash + configuration
