### PR TITLE
RFI over SSL? Get the certificate and store it alongside the injected file locally

### DIFF
--- a/glastopf/modules/handlers/emulators/rfi.py
+++ b/glastopf/modules/handlers/emulators/rfi.py
@@ -66,6 +66,7 @@ class RFIEmulator(base_emulator.BaseEmulator):
             if re.match('^https', injectd_url, re.IGNORECASE):
               host_name = req.get_host()
               cert_file = ssl.get_server_certificate((host_name, 443))
+              cert_name = self.store_file(cert_file)
 
         except IOError as e:
             logger.exception("Failed to fetch injected file, I/O error: {0}".format(e))
@@ -77,7 +78,6 @@ class RFIEmulator(base_emulator.BaseEmulator):
             file_name = None
         else:
             file_name = self.store_file(injected_file)
-            cert_name = self.store_file(cert_file)
         return file_name
 
     def handle(self, attack_event):

--- a/glastopf/modules/handlers/emulators/rfi.py
+++ b/glastopf/modules/handlers/emulators/rfi.py
@@ -20,6 +20,7 @@ import hashlib
 import os
 import re
 import logging
+import ssl
 
 import glastopf.sandbox.sandbox as sandbox
 from glastopf.modules.handlers import base_emulator
@@ -61,6 +62,11 @@ class RFIEmulator(base_emulator.BaseEmulator):
 	    req.add_unredirected_header('User-Agent','-')
             # FIXME: We need a timeout on read here
             injected_file = urllib2.urlopen(req, timeout=4).read()
+            #  If the file is hosted on a SSL enabled host get the certificate
+            if re.match('^https', injectd_url, re.IGNORECASE):
+              host_name = req.get_host()
+              cert_file = ssl.get_server_certificate((host_name, 443))
+
         except IOError as e:
             logger.exception("Failed to fetch injected file, I/O error: {0}".format(e))
             # TODO: We want to handle the case where we can't download
@@ -71,6 +77,7 @@ class RFIEmulator(base_emulator.BaseEmulator):
             file_name = None
         else:
             file_name = self.store_file(injected_file)
+            cert_name = self.store_file(cert_file)
         return file_name
 
     def handle(self, attack_event):


### PR DESCRIPTION
Not implemented:
The pem file is not transferred via hpfeeds. I could probably figure out how to, if I get some pointers =) 