### PR TITLE
Improve handling of none standard SSL ports

### DIFF
--- a/glastopf/modules/handlers/emulators/rfi.py
+++ b/glastopf/modules/handlers/emulators/rfi.py
@@ -65,14 +65,14 @@ class RFIEmulator(base_emulator.BaseEmulator):
             injected_file = urllib2.urlopen(req, timeout=4).read()
             #  If the file is hosted on a SSL enabled host get the certificate
             if re.match('^https', injectd_url, re.IGNORECASE):
-              proto, rest = urllib2.splittype(injectd_url)
-              host, rest = urllib2.splithost(rest)
-              host, port = urllib2.splitport(host)
-              if port is None:
-               port = 443
+                proto, rest = urllib2.splittype(injectd_url)
+                host, rest = urllib2.splithost(rest)
+                host, port = urllib2.splitport(host)
+                if port is None:
+                    port = 443
 
-              cert_file = ssl.get_server_certificate((host, int(port)))
-              cert_name = self.store_file(cert_file)
+                cert_file = ssl.get_server_certificate((host, int(port)))
+                cert_name = self.store_file(cert_file)
 
         except IOError as e:
             logger.exception("Failed to fetch injected file, I/O error: {0}".format(e))

--- a/glastopf/modules/handlers/emulators/rfi.py
+++ b/glastopf/modules/handlers/emulators/rfi.py
@@ -65,8 +65,13 @@ class RFIEmulator(base_emulator.BaseEmulator):
             injected_file = urllib2.urlopen(req, timeout=4).read()
             #  If the file is hosted on a SSL enabled host get the certificate
             if re.match('^https', injectd_url, re.IGNORECASE):
-              host_name = req.get_host()
-              cert_file = ssl.get_server_certificate((host_name, 443))
+              proto, rest = urllib2.splittype(injectd_url)
+              host, rest = urllib2.splithost(rest)
+              host, port = urllib2.splitport(host)
+              if port is None:
+               port = 443
+
+              cert_file = ssl.get_server_certificate((host, int(port)))
               cert_name = self.store_file(cert_file)
 
         except IOError as e:


### PR DESCRIPTION
Improve handling of none standard SSL ports

Example:

https://example.com
https://example.com:443
https://example.com:449