### PR TITLE
Fix displaying of comments with unicode characters

### DIFF
--- a/glastopf/modules/handlers/emulators/comments.py
+++ b/glastopf/modules/handlers/emulators/comments.py
@@ -32,7 +32,7 @@ class CommentPoster(base_emulator.BaseEmulator):
             try:
                 comment = (parse_qs(attack_event.http_request.request_body)
                            ['comment'][0])
-                clean_comment = self.html_escape(comment)
+                clean_comment = self.html_escape(comment.encode('ascii', 'backslashreplace'))
                 clean_comment = "<br/><br/>" + clean_comment
                 comment = "<br/><br/>" + comment
             except KeyError:
@@ -57,7 +57,7 @@ class CommentPoster(base_emulator.BaseEmulator):
             else:
                 general_comments = ''
 
-            display_comments = str(general_comments)
+            display_comments = general_comments.decode('string_escape')
             template = Template(dork_page.read())
             response = template.safe_substitute(login_msg="", comments=display_comments)
             attack_event.http_request.set_response(response)


### PR DESCRIPTION
like:
Detta Ã¤r

Hi, fix for https://github.com/glastopf/glastopf/issues/238

works for this comment for example:
Detta Ã¤r sannolikt den mest informativ artikel om detta Ã¤mne jag har lÃ¤st pÃ¥ sistone. Jag hÃ¥ller med och du Ã¤r pÃ¥ den punkten. Grattis till ett vÃ¤l utfÃ¶rt arbete.

but only for /comments part of glastopf

http://localhost/ won't work. It looks there is also other problem.

right now, it would display:
Detta \xc3\x83\xc2\xa4r sannolikt den mest informativ artikel om detta \xc3\x83\xc2\xa4mne jag har l\xc3\x83\xc2\xa4st p\xc3\x83\xc2\xa5 sistone. Jag h\xc3\x83\xc2\xa5ller med och du \xc3\x83\xc2\xa4r p\xc3\x83\xc2\xa5 den punkten. Grattis till ett v\xc3\x83\xc2\xa4l utf\xc3\x83\xc2\xb6rt arbete.

I tried these things, but obiously I am missing something:

import BeautifulSoup
from BeautifulSoup import *
display_comments = BeautifulSoup(general_comments.encode('utf-8'), convertEntities=BeautifulSoup.HTML_ENTITIES)

display_comments = general_comments.decode('string_escape')

lala = general_comments.encode('unicode_escape')

lala = general_comments.decode('ascii', 'ignore')
lala2 = str(lala.replace('\\\\', '\\'))
print lala2
display_comments = lala2.decode('string_escape')