### PR TITLE
Added Glastopf version number support to logs/db

### DIFF
--- a/glastopf/glastopf.py
+++ b/glastopf/glastopf.py
@@ -162,7 +162,7 @@ class GlastopfHoneypot(object):
                 sys.exit(1)
         else:
             default_db = "sqlite:///db/glastopf.db"
-            logger.info("Main datbase has been disabled, dorks will be stored in: {0}".format(default_db))
+            logger.info("Main database has been disabled, dorks will be stored in: {0}".format(default_db))
             #db will only be used for dorks
             sqla_engine = create_engine("sqlite:///db/glastopf.db")
             #maindb = log_sql.Database(sqla_engine)

--- a/glastopf/glastopf.py
+++ b/glastopf/glastopf.py
@@ -244,6 +244,9 @@ class GlastopfHoneypot(object):
         attack_event.raw_request = raw_request
         attack_event.sensor_addr = sensor_addr
 
+        # Add glastopf version
+        attack_event.version = __version__
+
         attack_event.http_request = HTTPHandler(raw_request, addr, self.options['banner'], sys_version=' ')
 
         if self.options["proxy_enabled"] == "True":

--- a/glastopf/glastopf.py
+++ b/glastopf/glastopf.py
@@ -161,10 +161,10 @@ class GlastopfHoneypot(object):
                 logger.error("Invalid connection string.")
                 sys.exit(1)
         else:
-            default_db = "sqlite://db/glastopf.db"
+            default_db = "sqlite:///db/glastopf.db"
             logger.info("Main datbase has been disabled, dorks will be stored in: {0}".format(default_db))
             #db will only be used for dorks
-            sqla_engine = create_engine("sqlite://db/glastopf.db")
+            sqla_engine = create_engine("sqlite:///db/glastopf.db")
             #maindb = log_sql.Database(sqla_engine)
             dorkdb = database_sqla.Database(sqla_engine)
             #disable usage of main logging datbase

--- a/glastopf/glastopf.py
+++ b/glastopf/glastopf.py
@@ -164,7 +164,7 @@ class GlastopfHoneypot(object):
             default_db = "sqlite:///db/glastopf.db"
             logger.info("Main database has been disabled, dorks will be stored in: {0}".format(default_db))
             #db will only be used for dorks
-            sqla_engine = create_engine("sqlite:///db/glastopf.db")
+            sqla_engine = create_engine(default_db)
             #maindb = log_sql.Database(sqla_engine)
             dorkdb = database_sqla.Database(sqla_engine)
             #disable usage of main logging datbase

--- a/glastopf/modules/events/attack.py
+++ b/glastopf/modules/events/attack.py
@@ -29,6 +29,7 @@ class AttackEvent(object):
         self.source_addr = None
         self.matched_pattern = "unknown"
         self.file_name = None
+        self.version = None
 
     def event_dict(self):
         event_dict = {
@@ -38,5 +39,6 @@ class AttackEvent(object):
             "request_raw": self.http_request.request_raw,
             "pattern": self.matched_pattern,
             "filename": self.file_name,
+            "version": self.version,
         }
         return event_dict

--- a/glastopf/modules/reporting/auxiliary/log_syslog.py
+++ b/glastopf/modules/reporting/auxiliary/log_syslog.py
@@ -35,7 +35,7 @@ class LogSyslog(BaseLogger):
             try:
                 LogSyslog.logger
             except AttributeError:
-                LogSyslog.logger = logging.getLogger('glaspot_attack')
+                LogSyslog.logger = logging.getLogger('glastopf_attack')
                 LogSyslog.logger.propagate = False
                 if ":" in self.options['socket']:
                     host, port = self.options['socket'].split(":")
@@ -48,12 +48,13 @@ class LogSyslog(BaseLogger):
                 LogSyslog.logger.setLevel(logging.INFO)
 
     def insert(self, attack_event):
-        message = "Glaspot: %(pattern)s attack method from %(source)s against %(host)s:%(port)s. [%(method)s %(url)s]" % {
+        message = "Glastopf: %(pattern)s attack method from %(source)s against %(host)s:%(port)s. [%(method)s %(url)s] v:%(version)s" % {
             'pattern': attack_event.matched_pattern,
             'source': ':'.join((attack_event.source_addr[0], str(attack_event.source_addr[1]))),
             'host': attack_event.sensor_addr[0],
             'port': attack_event.sensor_addr[1],
             'method': attack_event.http_request.request_verb,
             'url': attack_event.http_request.request_url,
+            'version': attack_event.version,
         }
         LogSyslog.logger.info(message)

--- a/glastopf/modules/reporting/main/log_sql.py
+++ b/glastopf/modules/reporting/main/log_sql.py
@@ -82,6 +82,7 @@ class Database(object):
             Column('request_raw', TEXT),
             Column('pattern', String(20)),
             Column('filename', String(500)),
+            Column('version', String(10)),
         )
         #only creates if it cant find the schema
         meta.create_all(self.engine)


### PR DESCRIPTION
Added Glastopf version number support in logs and databases. 

Verified to work for Sqlite, Mysql, Hpfeeds and Syslog.

Logstash output and possible others will need to be updated to make use of these changes

This solves the issue: #169 

Please note that this requires a schema change ..

Also sneaked in a fix for the  #245.
